### PR TITLE
Fix GetScoreFromString; add a github action to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
     inputs: {}
 
 jobs:
-  release:
+  test:
     runs-on: ${{ matrix.os.runs-on }}
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,6 @@
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version Number'
-        default: '0.0.0.0'
-        required: true
-        type: string
-      create-release:
-        type: boolean
-        description: "Create Release"
+    inputs: {}
 
 jobs:
   release:
@@ -28,7 +20,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: restore
-      run: dotnet restore MusicXml -r ${{ matrix.os.arch }}
+      run: dotnet restore MusicXml.Tests -r ${{ matrix.os.arch }}
 
     - name: unit test
-      uses: RachelGanonNew/Run-All-.Net-Unit-Test@main
+      run: dotnet test MusicXml.Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version Number'
+        default: '0.0.0.0'
+        required: true
+        type: string
+      create-release:
+        type: boolean
+        description: "Create Release"
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os.runs-on }}
+
+    strategy:
+      matrix:
+        os: 
+          - runs-on: windows-latest
+            arch: win-x64
+          - runs-on: macos-latest
+            arch: osx-x64
+          - runs-on: ubuntu-latest
+            arch: linux-x64
+          
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: restore
+      run: dotnet restore MusicXml -r ${{ matrix.os.arch }}
+
+    - name: unit test
+      uses: RachelGanonNew/Run-All-.Net-Unit-Test@main

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 .svn/*
 MusicXml.Schema/*
+.vs/

--- a/MusicXml.Tests/MusicXmlParserTests.cs
+++ b/MusicXml.Tests/MusicXmlParserTests.cs
@@ -54,7 +54,7 @@ namespace MusicXml.Unit.Tests
 		{
 			const string knownEncodingDescription = "This is a sample description\nacross multiple lines\n";
 
-			Assert.That(_scoreWithStaffValues.Identification.Encoding.Description, Is.EqualTo(knownEncodingDescription));
+			Assert.That(_scoreWithStaffValues.Identification.Encoding.Description.Replace(Environment.NewLine,"\n"), Is.EqualTo(knownEncodingDescription));
 		}
 
 		[Test]
@@ -70,7 +70,7 @@ namespace MusicXml.Unit.Tests
 		{
 			const string knownEncodingSoftware = "Finale 2011 for Windows\nDolet 6.0 for Finale\n";
 
-			Assert.That(_scoreWithStaffValues.Identification.Encoding.Software, Is.EqualTo(knownEncodingSoftware));
+			Assert.That(_scoreWithStaffValues.Identification.Encoding.Software.Replace(Environment.NewLine,"\n"), Is.EqualTo(knownEncodingSoftware));
 		}
 
 		[Test]

--- a/MusicXml/MusicXmlParser.cs
+++ b/MusicXml/MusicXmlParser.cs
@@ -407,9 +407,12 @@ namespace MusicXml
 
 		private static XmlDocument GetXmlDocument(Stream stream)
 		{
+            var document = new XmlDocument();
+            document.XmlResolver = null;
 			using (var sr = new StreamReader(stream)) {
-				return GetXmlDocument(sr.ReadToEnd());
+                document.LoadXml(sr.ReadToEnd());
 			}
+			return document;
 		}
 
 		private static string GetFileContents(string filename)

--- a/MusicXml/MusicXmlParser.cs
+++ b/MusicXml/MusicXmlParser.cs
@@ -20,7 +20,7 @@ namespace MusicXml
 
 		public static Score GetScoreFromString(string str)
 		{
-			var document = GetXmlDocument(str);
+			var document = GetXmlDocumentFromString(str);
 			return GetScore(document);
 		}
 
@@ -404,6 +404,15 @@ namespace MusicXml
 
 			return document;
 		}
+
+		private static XmlDocument GetXmlDocumentFromString(string str) 
+		{
+            var document = new XmlDocument();
+            document.XmlResolver = null;
+			document.LoadXml(str);
+			return document;
+
+        }
 
 		private static XmlDocument GetXmlDocument(Stream stream)
 		{


### PR DESCRIPTION
1. Added a GetXmlDocumentFromString function that directly parses the string instead of parsing from the filepath given in the string. GetScoreFromString is changed to use this function.
2. Added a github action to run tests across windows, mac and linux.